### PR TITLE
Replaced wavread with audioread

### DIFF
--- a/snow-dots/classes/playable/dotsPlayableFile.m
+++ b/snow-dots/classes/playable/dotsPlayableFile.m
@@ -50,8 +50,8 @@ classdef dotsPlayableFile < dotsPlayable
             [filePath, fileName, fileType] = fileparts(soundFile);
             if strcmp(fileType, '.wav')
                 % MATLAB's builtin .wav reader
-                [self.waveform, self.sampleFrequency, self.bitsPerSample] = ...
-                    wavread(soundFile);
+                [self.waveform, self.sampleFrequency] = audioread(soundFile);
+                self.bitsPerSample = getfield(audioinfo(soundFile), 'BitsPerSample');
                 
             elseif strcmp(sfileType, '.mp3')
                 if exist('mp3read', 'file')


### PR DESCRIPTION
In the 2015b version of MATLAB, wavread was removed and we are expected to use audioread in its absence(see https://www.mathworks.com/help/matlab/release-notes.html?searchHighlight=wavread&s_tid=doc_srchtitle) 

I replaced wavread with both audioread and audioinfo to achieve the same functionality. The new audioread does not return the BitsPerSample information like the old wavread did so I had to use audioinfo to return that information. 

Ref:
https://www.mathworks.com/help/matlab/ref/audioread.html
https://www.mathworks.com/help/matlab/ref/audioinfo.html
Old wavread http://www.mathworks.com/help/releases/R2012b/matlab/ref/wavread.html?searchHighlight=wavread
